### PR TITLE
Add second screen to main window

### DIFF
--- a/src/main/java/seedu/address/ui/FullRecipeCard.java
+++ b/src/main/java/seedu/address/ui/FullRecipeCard.java
@@ -1,0 +1,41 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * An UI component that displays information of a {@code Recipe}.
+ */
+public class FullRecipeCard extends UiPart<Region> {
+    private static final String FXML = "FullRecipeListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final String recipe;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+
+    /**
+     * Creates a {@code IngredientCode} with the given {@code Ingredient} and index to display.
+     */
+    public FullRecipeCard(String string, int displayedIndex) { // To be updated
+        super(FXML);
+        this.recipe = string;
+        id.setText(displayedIndex + ". ");
+        name.setText(string);
+    }
+}
+

--- a/src/main/java/seedu/address/ui/FullRecipeListPanel.java
+++ b/src/main/java/seedu/address/ui/FullRecipeListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * Panel containing the list of recipes.
+ */
+public class FullRecipeListPanel extends UiPart<Region> {
+    private static final String FXML = "FullRecipeListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(RecipeListPanel.class);
+
+    // To be updated
+    @FXML
+    private ListView<String> fullRecipeListView;
+
+    /**
+     * Creates a {@code IngredientListPanel} with the given {@code ObservableList}.
+     */
+    public FullRecipeListPanel(ObservableList<String> recipeList) {
+        super(FXML);
+        System.out.println(recipeList);
+        fullRecipeListView.setItems(recipeList);
+        fullRecipeListView.setCellFactory(listView -> new FullRecipeListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Recipe} using an {@code RecipeCard}.
+     */
+    class FullRecipeListViewCell extends ListCell<String> { // To be updated
+        @Override
+        protected void updateItem(String string, boolean empty) {
+            super.updateItem(string, empty);
+
+            if (empty || string == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new FullRecipeCard(string, getIndex() + 1).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,12 +2,15 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
+import javafx.collections.transformation.FilteredList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
@@ -33,6 +36,8 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private IngredientListPanel ingredientListPanel;
+
+    private UiPart<Region> recipeListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -44,6 +49,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane ingredientListPanelPlaceholder;
+
+    @FXML
+    private StackPane recipeListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -113,6 +121,17 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         ingredientListPanel = new IngredientListPanel(logic.getFilteredIngredientList());
         ingredientListPanelPlaceholder.getChildren().add(ingredientListPanel.getRoot());
+        // Check the length of the filtered recipe
+        // If it is 1, then display full recipe
+        // Else show only name and ingredients
+        if (2 == 1) {
+            // Change this portion to logic.getFilteredRecipeList() once its up!!
+            // The thing below is just for temporary testing
+            recipeListPanel = new FullRecipeListPanel(new FilteredList<>(FXCollections.observableArrayList("hello")));
+        } else {
+            recipeListPanel = new RecipeListPanel(new FilteredList<>(FXCollections.observableArrayList("Full")));
+        }
+        recipeListPanelPlaceholder.getChildren().add(recipeListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/RecipeCard.java
+++ b/src/main/java/seedu/address/ui/RecipeCard.java
@@ -1,0 +1,40 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * An UI component that displays information of a {@code Recipe}.
+ */
+public class RecipeCard extends UiPart<Region> {
+    private static final String FXML = "RecipeListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final String recipe;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+
+    /**
+     * Creates a {@code IngredientCode} with the given {@code Ingredient} and index to display.
+     */
+    public RecipeCard(String string, int displayedIndex) { // To be updated
+        super(FXML);
+        this.recipe = string;
+        id.setText(displayedIndex + ". ");
+        name.setText(string);
+    }
+}

--- a/src/main/java/seedu/address/ui/RecipeListPanel.java
+++ b/src/main/java/seedu/address/ui/RecipeListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * Panel containing the list of recipes.
+ */
+public class RecipeListPanel extends UiPart<Region> {
+    private static final String FXML = "RecipeListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(RecipeListPanel.class);
+
+    // To be updated
+    @FXML
+    private ListView<String> recipeListView;
+
+    /**
+     * Creates a {@code IngredientListPanel} with the given {@code ObservableList}.
+     */
+    public RecipeListPanel(ObservableList<String> recipeList) {
+        super(FXML);
+        System.out.println(recipeList);
+        recipeListView.setItems(recipeList);
+        recipeListView.setCellFactory(listView -> new RecipeListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Recipe} using an {@code RecipeCard}.
+     */
+    class RecipeListViewCell extends ListCell<String> { // To be updated
+        @Override
+        protected void updateItem(String string, boolean empty) {
+            super.updateItem(string, empty);
+
+            if (empty || string == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new RecipeCard(string, getIndex() + 1).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/resources/view/FullRecipeListCard.fxml
+++ b/src/main/resources/view/FullRecipeListCard.fxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/FullRecipeListPanel.fxml
+++ b/src/main/resources/view/FullRecipeListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="fullRecipeListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.layout.HBox?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
          title="Recipe Book" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -46,12 +47,21 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="ingredientList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="ingredientListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+        <HBox VBox.vgrow="ALWAYS">
+          <VBox fx:id="ingredientList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10" />
+            </padding>
+            <StackPane fx:id="ingredientListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+
+          <VBox fx:id="recipeList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10" />
+            </padding>
+            <StackPane fx:id="recipeListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+        </HBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/RecipeListCard.fxml
+++ b/src/main/resources/view/RecipeListCard.fxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/RecipeListPanel.fxml
+++ b/src/main/resources/view/RecipeListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="recipeListView" VBox.vgrow="ALWAYS" />
+</VBox>


### PR DESCRIPTION
Currently, the main window is only able to display ingredients. As we move to having recipes, there needs to be a way to display them.

Having this second window allows for better viewing as well as not being so cluttered on the screen.