### PR TITLE
Add tests and bugfixes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RecipeViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecipeViewCommand.java
@@ -2,14 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Predicate;
-
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
+import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
 
 /**
  * Views a specific recipe in the recipe list.
@@ -22,27 +21,29 @@ public class RecipeViewCommand extends Command {
             + "uuid (greater or equal to 1)"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SUCCESS = "New ingredient added: %1$s";
-
-    private final Predicate<Recipe> predicate;
+    private final RecipeUuidMatchesPredicate predicate;
+    private final int uuid;
 
     /**
      * Creates an RecipeViewCommand to view the specified {@code Recipe}
      */
-    public RecipeViewCommand(Predicate<Recipe> predicate) {
+    public RecipeViewCommand(RecipeUuidMatchesPredicate predicate) {
         requireNonNull(predicate);
         this.predicate = predicate;
+        this.uuid = predicate.getId();
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        if (!model.hasRecipe(this.uuid)) {
+            throw new CommandException(Messages.MESSAGE_RECIPE_DOES_NOT_EXIST);
+        }
+
         model.updateFilteredRecipeList(predicate);
         ObservableList<Recipe> recipeLst = model.getFilteredRecipeList();
-
         assert recipeLst.size() == 1;
-        int uuid = recipeLst.get(0).getId();
         return new CommandResult(String.format(Messages.MESSAGE_RECIPE_LISTED, uuid));
     }
 

--- a/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.RecipeViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
@@ -24,7 +23,7 @@ public class RecipeViewCommandParser implements Parser<RecipeViewCommand> {
             return new RecipeViewCommand(new RecipeUuidMatchesPredicate(uuid));
         } catch (NumberFormatException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RecipeViewCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
@@ -1,12 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
 
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.RecipeViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
-import seedu.address.model.recipe.UniqueId;
 
 /**
  * Parser for the RecipeViewCommand, returns a RecipeViewCommand
@@ -19,20 +18,13 @@ public class RecipeViewCommandParser implements Parser<RecipeViewCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RecipeViewCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        int uuid;
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RecipeViewCommand.MESSAGE_USAGE));
-        }
         try {
-            uuid = Integer.parseInt(trimmedArgs);
-        } catch (NumberFormatException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RecipeViewCommand.MESSAGE_USAGE));
+            String trimmedArgs = args.trim();
+            int uuid = Integer.parseInt(trimmedArgs);
+            return new RecipeViewCommand(new RecipeUuidMatchesPredicate(uuid));
+        } catch (NumberFormatException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
-        if (!UniqueId.isValidId(uuid)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX,
-                    RecipeViewCommand.MESSAGE_USAGE));
-        }
-        return new RecipeViewCommand(new RecipeUuidMatchesPredicate(uuid));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeViewCommandParser.java
@@ -17,13 +17,14 @@ public class RecipeViewCommandParser implements Parser<RecipeViewCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RecipeViewCommand parse(String args) throws ParseException {
+        int uuid;
+        String trimmedArgs = args.trim();
         try {
-            String trimmedArgs = args.trim();
-            int uuid = Integer.parseInt(trimmedArgs);
-            return new RecipeViewCommand(new RecipeUuidMatchesPredicate(uuid));
+            uuid = Integer.parseInt(trimmedArgs);
         } catch (NumberFormatException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, RecipeViewCommand.MESSAGE_USAGE), pe);
         }
+        return new RecipeViewCommand(new RecipeUuidMatchesPredicate(uuid));
     }
 }

--- a/src/main/java/seedu/address/model/recipe/RecipeUuidMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeUuidMatchesPredicate.java
@@ -14,9 +14,13 @@ public class RecipeUuidMatchesPredicate implements Predicate<Recipe> {
         this.uuid = uuid;
     }
 
+    public int getId() {
+        return this.uuid;
+    }
+
     @Override
     public boolean test(Recipe recipe) {
-        return recipe.getId() == uuid;
+        return this.uuid == recipe.getId();
     }
 
     @Override
@@ -36,6 +40,6 @@ public class RecipeUuidMatchesPredicate implements Predicate<Recipe> {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("uuid", uuid).toString();
+        return new ToStringBuilder(this).add("uuid", this.uuid).toString();
     }
 }

--- a/src/main/java/seedu/address/model/recipe/UniqueId.java
+++ b/src/main/java/seedu/address/model/recipe/UniqueId.java
@@ -18,10 +18,6 @@ public class UniqueId {
         lastId = Math.max(lastId, id);
     }
 
-    public static boolean isValidId(int id) {
-        return id >= 1 && id <= lastId;
-    }
-
     public int getId() {
         return this.id;
     }

--- a/src/test/java/seedu/address/logic/commands/RecipeViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RecipeViewCommandTest.java
@@ -1,24 +1,22 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.RecipeBook;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.ingredient.NameContainsKeywordsPredicate;
-import seedu.address.model.recipe.Recipe;
-import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_RECIPE_DOES_NOT_EXIST;
 import static seedu.address.logic.Messages.MESSAGE_RECIPE_LISTED;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIngredients.getTypicalInventory;
 import static seedu.address.testutil.TypicalRecipe.getTypicalRecipeBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.recipe.Recipe;
+import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code RecipeViewCommand}.
@@ -75,7 +73,7 @@ public class RecipeViewCommandTest {
 
     @Test
     public void execute_invalidUuid_throwsInvalidUuidException() {
-        String expectedMessage = MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+        String expectedMessage = MESSAGE_RECIPE_DOES_NOT_EXIST;
 
         // boundary value analysis, using uuid 0 and -1
         RecipeUuidMatchesPredicate predicate1 = new RecipeUuidMatchesPredicate(0);
@@ -98,9 +96,9 @@ public class RecipeViewCommandTest {
     */
     @Test
     public void execute_deletedUuidRecipe_throwsInvalidUuidException() {
-        String expectedMessage = MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+        String expectedMessage = MESSAGE_RECIPE_DOES_NOT_EXIST;
 
-        Recipe deletedRecipe = model.getRecipe(0);
+        Recipe deletedRecipe = model.getRecipe(1);
         model.deleteRecipe(deletedRecipe);
 
         RecipeUuidMatchesPredicate predicate = new RecipeUuidMatchesPredicate(1);

--- a/src/test/java/seedu/address/logic/commands/RecipeViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RecipeViewCommandTest.java
@@ -1,0 +1,118 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.RecipeBook;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.ingredient.NameContainsKeywordsPredicate;
+import seedu.address.model.recipe.Recipe;
+import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_RECIPE_LISTED;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIngredients.getTypicalInventory;
+import static seedu.address.testutil.TypicalRecipe.getTypicalRecipeBook;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code RecipeViewCommand}.
+ */
+public class RecipeViewCommandTest {
+    private Model model = new ModelManager(getTypicalInventory(), new UserPrefs(), getTypicalRecipeBook());
+    private Model expectedModel = new ModelManager(getTypicalInventory(), new UserPrefs(), getTypicalRecipeBook());
+
+    @Test
+    public void equals() {
+        RecipeUuidMatchesPredicate firstPredicate = new RecipeUuidMatchesPredicate(1);
+        RecipeUuidMatchesPredicate secondPredicate = new RecipeUuidMatchesPredicate(2);
+
+        RecipeViewCommand recipeViewFirstCommand = new RecipeViewCommand(firstPredicate);
+        RecipeViewCommand recipeViewSecondCommand = new RecipeViewCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(recipeViewFirstCommand.equals(recipeViewFirstCommand));
+
+        // same values -> returns true
+        RecipeViewCommand recipeViewFirstCommandCopy = new RecipeViewCommand(firstPredicate);
+        assertTrue(recipeViewFirstCommand.equals(recipeViewFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(recipeViewFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(recipeViewFirstCommand.equals(null));
+
+        // different ingredient -> returns false
+        assertFalse(recipeViewFirstCommand.equals(recipeViewSecondCommand));
+    }
+
+    //TODO may not be the correct way to test groups of inputs might need to change test
+    @Test
+    public void execute_validUuid_recipeFound() {
+        String expectedMessage1 = String.format(MESSAGE_RECIPE_LISTED, 1);
+        String expectedMessage2 = String.format(MESSAGE_RECIPE_LISTED, 2);
+
+        // boundary value analysis, using uuid 1 and 2
+        RecipeUuidMatchesPredicate predicate1 = new RecipeUuidMatchesPredicate(1);
+        RecipeUuidMatchesPredicate predicate2 = new RecipeUuidMatchesPredicate(2);
+        RecipeViewCommand command1 = new RecipeViewCommand(predicate1);
+        RecipeViewCommand command2 = new RecipeViewCommand(predicate2);
+
+        // testing command1
+        expectedModel.updateFilteredRecipeList(predicate1);
+        assertCommandSuccess(command1, model, expectedMessage1, expectedModel);
+
+        // testing command2
+        expectedModel.updateFilteredRecipeList(predicate2);
+        assertCommandSuccess(command2, model, expectedMessage2, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidUuid_throwsInvalidUuidException() {
+        String expectedMessage = MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+
+        // boundary value analysis, using uuid 0 and -1
+        RecipeUuidMatchesPredicate predicate1 = new RecipeUuidMatchesPredicate(0);
+        RecipeUuidMatchesPredicate predicate2 = new RecipeUuidMatchesPredicate(-1);
+        RecipeViewCommand command1 = new RecipeViewCommand(predicate1);
+        RecipeViewCommand command2 = new RecipeViewCommand(predicate2);
+
+        // testing command1
+        expectedModel.updateFilteredRecipeList(predicate1);
+        assertCommandFailure(command1, model, expectedMessage);
+
+        // testing command2
+        expectedModel.updateFilteredRecipeList(predicate2);
+        assertCommandFailure(command2, model, expectedMessage);
+    }
+
+    /*
+    todo not sure if should have separate exceptions for searching uuid that are deleted using index for
+    todo getrecipe may not be appropriate either for the recipe is dictated by uuid
+    */
+    @Test
+    public void execute_deletedUuidRecipe_throwsInvalidUuidException() {
+        String expectedMessage = MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX;
+
+        Recipe deletedRecipe = model.getRecipe(0);
+        model.deleteRecipe(deletedRecipe);
+
+        RecipeUuidMatchesPredicate predicate = new RecipeUuidMatchesPredicate(1);
+        RecipeViewCommand command = new RecipeViewCommand(predicate);
+        assertCommandFailure(command, model, expectedMessage);
+    }
+
+    @Test
+    public void toStringMethod() {
+        RecipeUuidMatchesPredicate predicate = new RecipeUuidMatchesPredicate(1);
+        RecipeViewCommand recipeViewCommand = new RecipeViewCommand(predicate);
+        String expected = RecipeViewCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, recipeViewCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/RecipeViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RecipeViewCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.RecipeViewCommand;
+import seedu.address.model.recipe.RecipeUuidMatchesPredicate;
+
+public class RecipeViewCommandParserTest {
+
+    private RecipeViewCommandParser parser = new RecipeViewCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRecipeViewCommand() {
+        // no leading and trailing whitespaces
+        RecipeViewCommand expectedRecipeViewCommand =
+                new RecipeViewCommand(new RecipeUuidMatchesPredicate(1));
+        assertParseSuccess(parser, "1", expectedRecipeViewCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n 1 \t", expectedRecipeViewCommand);
+    }
+
+    @Test
+    public void parse_noArgs_throwsParseException() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RecipeViewCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Fix bugs for the view recipe feature

Implementation will cause invocation error if ViewRecipeCommand is
called on a uuid belonging to a recipe that has been deleted. This
is due to improper invalid uuid checks in the associated parser
class. Invalid uuid exception handling is also in the parse
method in the ViewRecipeCommandParser class and not in the execute
method in ViewRecipeCommand.

The invocation error is simply a bug that needs to be remedied. The
handling of invalid uuid should not be handled by the parser since
it is technically not a parse exception.

Let's fix the bug associated with viewing deleted recipes, and shift
invalid uuid checks to the ViewRecipeCommand class.

Additonal info:
- Tests for RecipeViewCommand and RecipeViewCommandParser added
- Method to check valid id from UniqueId class is deleted for it does not check validity for deleted items
- Consider doing away with the Index as a way to encode the uuid information into the parser for deleteCommand
