### PR TITLE
Implement bugfixes for UseCommand

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -103,6 +103,7 @@ Format: `use n/NAME [q/QUANTITY] [u/UNIT]`
 
 * If no quantity or unit is provided, the entire stock of the specified ingredient will be depleted.
 * If the quantity depleted exceeds the current quantity in stock, the entire stock will be depleted but will not go into the negative.
+* The quantity provided must be more than or equal to 0.
 
 Examples:
 *  `use n/Milk q/600 u/g` Depletes the current quantity of milk by 600g

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -37,7 +37,6 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_QUANTITY, PREFIX_UNIT);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        double amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_QUANTITY).get());
 
         Unit unit;
         try {
@@ -46,7 +45,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException("This is not a valid unit!");
         }
 
-        Quantity quantity = new Quantity(amount, unit);
+        Quantity quantity = ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get(), unit);
         Ingredient ingredient = new Ingredient(name, quantity);
 
         return new AddCommand(ingredient);

--- a/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModifyCommandParser.java
@@ -45,7 +45,6 @@ public class ModifyCommandParser implements Parser<ModifyCommand> {
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        double amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_QUANTITY).get());
 
         Unit unit;
         try {
@@ -54,8 +53,7 @@ public class ModifyCommandParser implements Parser<ModifyCommand> {
             throw new ParseException("This is not a valid unit!");
         }
 
-        Quantity quantity = new Quantity(amount, unit);
-
+        Quantity quantity = ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get(), unit);
         Ingredient newIngredient = new Ingredient(name, quantity);
 
         return new ModifyCommand(new UniqueId(id), newIngredient);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -51,17 +51,22 @@ public class ParserUtil {
     // Todo Add JavaDocs
     /**
      * Stub
-     * @param amount Stub
+     * @param quantStr Stub
      * @return Stub
      * @throws ParseException Stub
      */
-    public static double parseAmount(String amount) throws ParseException {
-        requireNonNull(amount);
+    public static Quantity parseQuantity(String quantStr, Unit unit) throws ParseException {
+        requireNonNull(quantStr);
+        double amount;
         try {
-            return Double.parseDouble(amount);
+            amount = Double.parseDouble(quantStr);
         } catch (NumberFormatException e) {
-            throw new ParseException("Invalid amount format: " + amount);
+            throw new ParseException("Invalid quantity: " + quantStr);
         }
+        if (amount < 0) {
+            throw new ParseException("Quantity cannot be negative");
+        }
+        return new Quantity(amount, unit);
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/UseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UseCommandParser.java
@@ -41,7 +41,6 @@ public class UseCommandParser implements Parser<UseCommand> {
             return new UseCommand(name, null);
         }
 
-        double amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_QUANTITY).get());
         Unit unit;
         try {
             unit = ParserUtil.parseUnitOfIngredient(argMultimap.getValue(PREFIX_UNIT).get());
@@ -49,7 +48,8 @@ public class UseCommandParser implements Parser<UseCommand> {
             throw new ParseException("This is not a valid unit!");
         }
 
-        Quantity quantity = new Quantity(amount, unit);
+        Quantity quantity = ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get(), unit);
+
         return new UseCommand(name, quantity);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -79,12 +79,12 @@ public class ParserUtilTest {
 
     @Test
     public void parseAmount_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseAmount((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseQuantity((String) null, Unit.GRAM));
     }
 
     @Test
     public void parseAmount_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_AMOUNT));
+        assertThrows(ParseException.class, () -> ParserUtil.parseQuantity(INVALID_AMOUNT, Unit.GRAM));
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/UseCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UseCommandParserTest.java
@@ -37,4 +37,16 @@ public class UseCommandParserTest {
         UseCommand command = new UseCommand(new Name("Flour"), new Quantity(100.0, Unit.GRAM));
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_FLOUR, command);
     }
+
+    @Test
+    public void parse_negativeQuantity_throwsParseException() {
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + NAME_DESC_FLOUR + " q/-100 " + UNIT_DESC_FLOUR,
+                "Quantity cannot be negative");
+    }
+
+    @Test
+    public void parse_nonNumericQuantity_throwsParseException() {
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + NAME_DESC_FLOUR + " q/onehundred " + UNIT_DESC_FLOUR,
+                "Invalid quantity: onehundred");
+    }
 }


### PR DESCRIPTION
UseCommand feature allows negative input to be keyed in by user. The parse exceptions raised in parsing the quantity of ingredient refers to the quantity as "amount" instead.

Let's raise a parse exception when the user inputs a negative quantity, and change the parseAmount method in ParserUtil class to parseQuantity instead. The method will take in an extra unit parameter, and output a Quantity object instead of a double value.

The method was changed to make it more specific towards parsing only quantity since our Recipe Book never needs to parse a raw number. This also allows the error messages in the parse exception to be more appropriate.

The relevant tests for negative values are also added.